### PR TITLE
remove mopidy spotify support for the moment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,6 @@ RUN apt-get update \
     mopidy=${MOPDIY_VERSION} \
     mopidy-dleyna \
     mopidy-mpd \
-    libspotify-dev \
-    libspotify12 \
-    python3-spotify \
  # Clean-up
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* ~/.cache

--- a/mopidy.conf
+++ b/mopidy.conf
@@ -14,8 +14,5 @@ zeroconf = Mopidy HTTP server on $hostname
 enabled = false
 hostname = 0.0.0.0
 
-[spotify]
-enabled = false
-
 [audio]
 output=alsasink

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 Mopidy-dLeyna
 Mopidy-Local
 mopidy-musicbox-webclient
-Mopidy-Spotify


### PR DESCRIPTION
### Description

Remove Spotify support, for the moment

### References

* Original Issue, [#110](https://github.com/mopidy/mopidy-spotify/issues/110)